### PR TITLE
Deshabilitado el plugin contextmenu del editor CKEditor

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -54,6 +54,11 @@ module.exports = function (grunt) {
                 nonnull: true
             }
         },
+        jshint: {
+            all: ['Gruntfile.js', 
+              'mod/somenergia-theme/**/*.js', 
+              '.test/**/*.js']
+        },
         casperjs: {
             options: {
                 async: {
@@ -66,10 +71,11 @@ module.exports = function (grunt) {
 
     grunt.loadNpmTasks('grunt-contrib-less');
     grunt.loadNpmTasks('grunt-contrib-csslint');
+    grunt.loadNpmTasks('grunt-contrib-jshint');
     grunt.loadNpmTasks('grunt-casperjs');
 
     grunt.registerTask('build', ['less']);
-    grunt.registerTask('default', ['csslint']);
+    grunt.registerTask('default', ['csslint', 'jshint']);
     grunt.registerTask('integration', ['casperjs']);
 
 };

--- a/mod/somenergia-theme/manifest.xml
+++ b/mod/somenergia-theme/manifest.xml
@@ -3,7 +3,7 @@
     <id>somenergia-theme</id>
     <name>SomEnergia Theme</name>
     <author>Rubén Martín</author>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <category>theme</category>
     <description>Som Energia Platform Theme</description>
     <website>https://www.somenergia.coop</website>
@@ -45,6 +45,16 @@
         <type>priority</type>
         <priority>after</priority>
         <plugin>custom_index_widgets</plugin>
+    </requires>
+    <requires>
+        <type>priority</type>
+        <priority>after</priority>
+        <plugin>ckeditor</plugin>
+    </requires>
+    <requires>
+        <type>priority</type>
+        <priority>after</priority>
+        <plugin>ckeditor_addons</plugin>
     </requires>
     <suggests>
         <type>plugin</type>

--- a/mod/somenergia-theme/views/default/boot/somenergia-theme.js
+++ b/mod/somenergia-theme/views/default/boot/somenergia-theme.js
@@ -1,0 +1,26 @@
+define(function (require) {
+  var elgg = require("elgg");
+  var Plugin = require("elgg/Plugin");
+  /**
+   * Theme init
+   */
+  function theme_init() {
+
+  }
+
+  /**
+   * Config CKEditor
+   * Override config from CKEditor Addons
+   */
+  function config_editor(hook, type, params, config) {
+    config.removePlugins = 'liststyle,contextmenu,tabletools,resize';
+    return config;
+  }
+
+  return new Plugin({
+    init: function () {
+      elgg.register_hook_handler("init", "system", theme_init);
+      elgg.register_hook_handler('config', 'ckeditor', config_editor);
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "grunt": "^1.0.1",
     "grunt-casperjs": "^2.2.1",
     "grunt-contrib-csslint": "^2.0.0",
+    "grunt-contrib-jshint": "^1.1.0",
     "grunt-contrib-less": "^1.4.1",
     "phantom": "^4.0.5"
   }


### PR DESCRIPTION
El plugin CKEditor addons ( Permite modificar la configuración del edito de texto ) habilita el plugin [contextmenu](https://ckeditor.com/cke4/addon/contextmenu) de ckeditor y deshabilita la configuración por defecto del nagevador.

Los usuarios solo tiene la opción de pegar en el menú. por lo que no tienen las opciones por defecto del navegador en el menú, como los sugerencias de corrección del texto.
![screenshot from 2017-10-09 15-12-09](https://user-images.githubusercontent.com/4323228/31340116-7623c1ae-ad05-11e7-8f75-5ba18516a71d.png)

En el plugin de somenergia-theme he sobrescrito la configuración para revertir la situación y que se muestre el menú por defecto del navegador. (No tengo caputura)

@davidromani Podrías aceptar el pull request y subirlo a producción. 